### PR TITLE
RTC-10855 - Toast left and right icon should have their own space

### DIFF
--- a/src/components/atoms/_toast.scss
+++ b/src/components/atoms/_toast.scss
@@ -1,7 +1,9 @@
 .tk-toast {
+    align-items: center;
     background-color: $scolor-graphite-plus-48;
     border-radius: toRem(8);
     color: $scolor-graphite-minus-96;
+    display: flex;
     line-height: toRem(20);
     padding: toRem(10) toRem(16) toRem(10) toRem(16);
     width: fit-content;


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-10855

**Before**
<img width="543" alt="Screenshot 2021-06-01 at 10 50 26" src="https://user-images.githubusercontent.com/60875212/120295218-3ba6ce00-c2c7-11eb-89a1-f6280883d4e9.png">

**After**
<img width="547" alt="Screenshot 2021-06-01 at 10 50 34" src="https://user-images.githubusercontent.com/60875212/120295224-3e092800-c2c7-11eb-9688-328bd6a4f77e.png">
