### PR TITLE
APP-4195 Align Modal with UX requirements

### DIFF
--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -102,6 +102,9 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     @extend .tk-pr-1;
     @extend .tk-py-1;
 
+    // Vendor prefix because the custom scrollbar is not yet supported in Autoprefixer
+    // See https://github.com/postcss/autoprefixer/issues/821
+    //     https://caniuse.com/css-scrollbar
     &::-webkit-scrollbar {
       width: toRem(5);
     }

--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -93,14 +93,18 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     }
   }
 
+  &__header {
+    @extend .tk-mt-2;
+  }
+
   &__body {
     flex: 1;
     position: relative;
-    min-height: toRem(32);
+    min-height: toRem(64);
     overflow-x: auto;
     overflow-y: scroll;
+    @extend .tk-mt-2;
     @extend .tk-pr-1;
-    @extend .tk-py-1;
 
     // Vendor prefix because the custom scrollbar is not yet supported in Autoprefixer
     // See https://github.com/postcss/autoprefixer/issues/821
@@ -115,9 +119,10 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   }
 
   &__footer {
+    @extend .tk-mt-2;
     position: relative;
     display: flex;
     justify-content: flex-end;
-    @extend .tk-mt-2;
+    flex-wrap: wrap;
   }
 }

--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -18,6 +18,7 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
 }
 
 .tk-dialog {
+  $maxSize: calc(100% - #{toRem(24 * 2)});
   display: flex;
   flex-direction: column;
   position: relative;
@@ -25,7 +26,8 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   box-sizing: border-box;
   min-width: toRem(296);
   min-height: toRem(164);
-  max-height: calc(100% - #{toRem(24 * 2)});
+  max-height: $maxSize;
+  max-width: $maxSize;
   box-shadow: 0 0 toRem(4) $dialog-box-shadow-bottom,
     0 toRem(8) toRem(24) $dialog-box-shadow-sides;
   background: $--tk-dialog-background-color;
@@ -42,7 +44,7 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   }
 
   &--medium {
-    width: toRem(480);
+    width: toRem(448);
   }
 
   &--large {

--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -99,8 +99,6 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
 
   &__body {
     flex: 1;
-    position: relative;
-    min-height: toRem(64);
     overflow-x: auto;
     overflow-y: scroll;
     @extend .tk-mt-2;
@@ -120,7 +118,6 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
 
   &__footer {
     @extend .tk-mt-2;
-    position: relative;
     display: flex;
     justify-content: flex-end;
     flex-wrap: wrap;

--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -18,10 +18,14 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
 }
 
 .tk-dialog {
+  display: flex;
+  flex-direction: column;
   position: relative;
   z-index: $z-index-dialog;
   box-sizing: border-box;
   min-width: toRem(296);
+  min-height: toRem(164);
+  max-height: calc(100% - #{toRem(24 * 2)});
   box-shadow: 0 0 toRem(4) $dialog-box-shadow-bottom,
     0 toRem(8) toRem(24) $dialog-box-shadow-sides;
   background: $--tk-dialog-background-color;
@@ -49,9 +53,6 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     width: 100%;
   }
   /* Subcomponents */
-  &__header {
-    min-height: toRem(16);
-  }
   &__title {
     @extend .tk-pr-2;
     @extend .tk-typography--h1;
@@ -91,8 +92,8 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
   }
 
   &__body {
+    flex: 1;
     position: relative;
-    max-height: calc(100vh - 225px);
     min-height: toRem(32);
     overflow-x: auto;
     overflow-y: scroll;


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4195

**Changes**

Align Modal with UX requirements:
- Wrap elements in the footer
- Fix width of the Modal in 'medium'
- Add space between elements (border - title - header - body - footer - border)
- Add a marge (24px) between the Modal and the window

Clean code:
- Add comments about the vendor prefix
- Remove unused CSS properties

Demo

https://user-images.githubusercontent.com/66668470/123246389-0700ed80-d4e6-11eb-873b-9ba79c14a765.mov



(Related PR: https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-components/pull/249)