### PR TITLE
APP-4338: Update `TextArea` minimum height when `rows` attribute is provided

### DIFF
--- a/src/components/atoms/_input.scss
+++ b/src/components/atoms/_input.scss
@@ -3,9 +3,11 @@
 }
 
 textarea.tk-input {
-  $height: toRem(110);
-  min-height: $height;
   text-overflow: ellipsis;
+
+  &:not([rows]) {
+    min-height: toRem(110);
+  }  
 }
 
 .tk-input {


### PR DESCRIPTION
**APP-4338: Update `TextArea` minimum height when `rows` attribute is provided**
    
The HTML `rows` attribute defines the number of initial lines to display in the HTML `textarea`. When given, it enters in conflict with the `min-height` of the `TextArea`.
Today, the `min-height` is set to `110px` (~5 lines), so when the given `rows` is greater or equal to `5`, it works, but not when it's lower than `5` (because the textarea will have a minimum of 5 lines).

The solution here is to set the `min-height` only when the `rows` is not given.

--------

`<TextArea rows={2} .../>`

![Screenshot 2021-07-20 at 15 20 33](https://user-images.githubusercontent.com/66251236/126341150-b8a8a1b2-1461-410e-baf9-0ec764be7ebf.png)


--------

`<TextArea .../>` (not set)

![Screenshot 2021-07-20 at 15 21 11](https://user-images.githubusercontent.com/66251236/126341158-5c6eb8c2-e56f-495d-8101-ade315277a3a.png)

--------

`<TextArea rows={10} .../>`

![Screenshot 2021-07-20 at 15 21 31](https://user-images.githubusercontent.com/66251236/126341159-648275a1-cea1-4dc5-aa71-4c0142cf7e6b.png)

--------

JIRA ticket: [https://perzoinc.atlassian.net/browse/APP-4338](https://perzoinc.atlassian.net/browse/APP-4338)