### PR TITLE
Fixing tk-text-ellipsis component

### DIFF
--- a/src/components/containers/_text-ellipsis.scss
+++ b/src/components/containers/_text-ellipsis.scss
@@ -1,11 +1,6 @@
 .tk-text-ellipsis {
+    display: -webkit-inline-box;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
     -webkit-box-orient: vertical;
-
-    &--multiple-rows {
-        display: -webkit-inline-box;
-        white-space: normal;
-    }
 }


### PR DESCRIPTION
- display: -webkit-inline-box should be used for the base component
- No need to have white-space specified