### PR TITLE
Fixing text-ellipsis for really long continuous strings, for example a link

### DIFF
--- a/src/components/containers/_text-ellipsis.scss
+++ b/src/components/containers/_text-ellipsis.scss
@@ -1,6 +1,7 @@
 .tk-text-ellipsis {
-    display: -webkit-inline-box;
+    display: -webkit-box;
     overflow: hidden;
+    overflow-wrap: break-word;
     text-overflow: ellipsis;
     -webkit-box-orient: vertical;
 }

--- a/stories/text-ellipsis.stories.js
+++ b/stories/text-ellipsis.stories.js
@@ -21,6 +21,13 @@ export const TextEllipsis = () => {
                 Really, really, really, really, really, really, long text that gets cut!
             </p>
         </div>
+
+        <li>Long continuous string</li>
+        <div style="background: grey; margin: 16px 0px; padding: 16px; width: 200px">
+            <p class="tk-text-ellipsis tk-text-ellipsis__multiple-rows" style="-webkit-line-clamp: 2">
+                Reallyreallyreallyreallylongcontinuousstringforexamplealink
+            </p>
+        </div>
     
     </div>
     `);


### PR DESCRIPTION
In SFE-RTC we have a link that has TextEllipsis, this fixes the correct behaviour. 2-line ellipsis:

**Before:**
<img width="329" alt="Screenshot 2021-08-10 at 15 52 45" src="https://user-images.githubusercontent.com/60875212/128879395-45dfd20d-8454-41dd-bbfc-67a44e879b36.png">

**After:**
<img width="350" alt="Screenshot 2021-08-10 at 15 52 31" src="https://user-images.githubusercontent.com/60875212/128879338-d06a0b1b-77df-4a48-b267-9df20626cb5e.png">
