### PR TITLE
APP-4464 Remove the border from Dialog scrollbar

### DIFF
--- a/src/components/atoms/_dialog.scss
+++ b/src/components/atoms/_dialog.scss
@@ -113,6 +113,8 @@ $dialog-scrollbar-box-shadow: rgba($scolor-black, 0.5);
     &::-webkit-scrollbar-thumb {
       border-radius: toRem(5);
       background-color: $dialog-scrollbar-box-shadow;
+      // Remove the border, because Mana defines a 4px transparent border that reduces the width of our scrollbar.
+      border: none;
     }
   }
 


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4464

**Changes**
Remove the border from Dialog scrollbar because Mana defines a 4px transparent border that reduces the width of our scrollbar.

**Demo in StoryBook**
![Screenshot 2021-09-14 at 11 16 16](https://user-images.githubusercontent.com/66668470/133230893-0bff24aa-c72e-487d-8e42-ba35b6d79575.png)
