### PR TITLE
RTC-10961 - Improvements to text-ellipsis styles

### DIFF
--- a/src/components/atoms/_tooltip.scss
+++ b/src/components/atoms/_tooltip.scss
@@ -18,5 +18,6 @@
   
   &__wrapper {
     display: inline-block;
+    max-width: 100%;
   }
 }

--- a/src/components/containers/_text-ellipsis.scss
+++ b/src/components/containers/_text-ellipsis.scss
@@ -1,8 +1,14 @@
 .tk-text-ellipsis {
-    display: -webkit-box;
+    display: block;
     overflow: hidden;
     overflow-wrap: break-word;
     text-overflow: ellipsis;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
+    white-space: nowrap;
+
+    &__multiple-rows {
+        display: -webkit-box;
+        white-space: normal;
+    }
 }

--- a/stories/stories.scss
+++ b/stories/stories.scss
@@ -117,3 +117,10 @@ pre {
   --tk-button-color-primary-hover: green;
   --tk-button-color-primary-text: white;
 }
+
+.text-ellipsis-container {
+  background: grey;
+  margin: 16px 0px 64px 16px;
+  padding: 16px;
+  width: 300px
+} 

--- a/stories/text-ellipsis.stories.js
+++ b/stories/text-ellipsis.stories.js
@@ -9,23 +9,40 @@ export const TextEllipsis = () => {
         <h1>Text Ellipsis</h1>
         
         <li>1 row</li>
-        <div style="background: grey; margin: 16px 0px; padding: 16px; width: 200px">
+        <div class="text-ellipsis-container">
             <p class="tk-text-ellipsis" style="-webkit-line-clamp: 1">
                 Really, really, really, really, really, really, long text that gets cut!
             </p>
         </div>
 
         <li>2 rows</li>
-        <div style="background: grey; margin: 16px 0px; padding: 16px; width: 200px">
-            <p class="tk-text-ellipsis" style="-webkit-line-clamp: 2">
-                Really, really, really, really, really, really, long text that gets cut!
+        <div class="text-ellipsis-container">
+            <p class="tk-text-ellipsis tk-text-ellipsis__multiple-rows" style="-webkit-line-clamp: 2">
+                Really, really, really, really, really, really, really, really, really, really, long text that gets cut!
             </p>
         </div>
 
-        <li>Long continuous string</li>
-        <div style="background: grey; margin: 16px 0px; padding: 16px; width: 200px">
-            <p class="tk-text-ellipsis" style="-webkit-line-clamp: 2">
+        <li>Long continuous string - First word</li>
+        <div class="text-ellipsis-container">
+            <p class="tk-text-ellipsis" style="-webkit-line-clamp: 1">
                 Reallyreallyreallyreallylongcontinuousstringforexamplealink
+            </p>
+        </div>
+
+        <li>Long continuous string - Last word</li>
+        <div class="text-ellipsis-container">
+            <p class="tk-text-ellipsis" style="-webkit-line-clamp: 1">
+                A few words before the reallyreallyreallyreallylongcontinuousstringforexamplealink
+            </p>
+        </div>
+
+        <li>Long continuous string - 2 rows - Last word</li>
+        <p style="font-weight: bold">
+            A known limitation of text-ellipsis is if the last word of a multi-line ellipsis is a continuous string it will ellipse before the end.
+        </p>
+        <div class="text-ellipsis-container">
+            <p class="tk-text-ellipsis tk-text-ellipsis__multiple-rows" style="-webkit-line-clamp: 2">
+                This is a really, really, really, really, really, really, really, really, reallyreallyreallylongcontinuousstringforexamplealink
             </p>
         </div>
     


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-10961

If there is a long continuous string that is not the first word on a row text-ellipsis didn't work previously. This adds support for one-row ellipsis but it still doesn't work for multiple rows.

From the story:
<img width="1091" alt="Screenshot 2021-09-27 at 10 00 48" src="https://user-images.githubusercontent.com/60875212/134868176-252c00a7-0b03-4ebe-8e5b-2edbe1dc3887.png">