### PR TITLE
APP-4649 Icon uses the inherited color 

### DIFF
--- a/src/components/atoms/_button.scss
+++ b/src/components/atoms/_button.scss
@@ -88,7 +88,7 @@ $tk-button-size: toRem(32);
       min-width: $tk-button-size;
     }
   }
-  .tk-icon-loading {
+  .tk-button-icon--loading {
     position: absolute;
     margin: 0 auto;
     top: 25%;

--- a/src/utils/mixins/_buttons.scss
+++ b/src/utils/mixins/_buttons.scss
@@ -1,15 +1,24 @@
-/* Define color on current text and eventual font icons */
-@mixin addFontIconColor($fontColor) {
-  // Icon styling selector takes precendence over the button colors
-  &,
-  i {
-    color: $fontColor;
-  }
-}
 @mixin addIconSize($size) {
   &,
   i {
     font-size: toRem($size);
+  }
+}
+
+@mixin getButtonStyle(
+  $colorMap,
+  $textColor,
+  $backgroundColor,
+  $borderColor: false
+) {
+  $color: map-get($colorMap, $textColor);
+  color: $color;
+  background-color: map-get($colorMap, $backgroundColor);
+  @if $borderColor {
+    @include addBorder(toRem(2), map-get($colorMap, $borderColor));
+  }
+  .tk-button-icon--loading {
+    color: $color;
   }
 }
 
@@ -34,34 +43,19 @@
   background-color: map-get($colorMap, default);
   color: map-get($colorMap, text);
   &:hover {
-    background-color: map-get($colorMap, hover);
-    color: map-get($colorMap, hoverText);
-    .tk-button-icon--loading {
-      color: map-get($colorMap, hoverText);
-    }
+    @include getButtonStyle($colorMap, hoverText, hover);
   }
   &:active {
-    background-color: map-get($colorMap, active);
-    color: map-get($colorMap, activeText);
-    .tk-button-icon--loading {
-      color: map-get($colorMap, activeText);
-    }
+    @include getButtonStyle($colorMap, activeText, active);
   }
   &:disabled {
-    background-color: map-get($colorMap, disabled);
-    color: map-get($colorMap, textDisabled);
-    .tk-button-icon--loading {
-      color: map-get($colorMap, textDisabled);
-    }
+    @include getButtonStyle($colorMap, textDisabled, disabled);
   }
   &:disabled.loading {
     background-color: map-get($colorMap, default);
   }
   &.loading {
-    color: map-get($colorMap, text);
-    .tk-button-icon--loading {
-      color: map-get($colorMap, text);
-    }
+    @include getButtonStyle($colorMap, text, default);
   }
   @include focus-visible($colorMap);
 }
@@ -72,35 +66,18 @@
   color: map-get($colorMap, default);
   @include addBorder(toRem(2), map-get($colorMap, default));
   &:hover {
-    background-color: map-get($colorMap, hover);
-    color: map-get($colorMap, hoverText);
-    @include addBorder(toRem(2), map-get($colorMap, hoverText));
-    .tk-button-icon--loading {
-      color: map-get($colorMap, hoverText);
-    }
+    @include getButtonStyle($colorMap, hoverText, hover, hoverText);
   }
   &:active {
-    background-color: map-get($colorMap, active);
-    color: map-get($colorMap, activeText);
-    @include addBorder(toRem(2), map-get($colorMap, activeText));
-    .tk-button-icon--loading {
-      color: map-get($colorMap, activeText);
-    }
+    @include getButtonStyle($colorMap, activeText, active, activeText);
   }
   &:disabled {
+    @include getButtonStyle($colorMap, textDisabled, disabled, disabled);
     background-color: transparent;
-    color: map-get($colorMap, textDisabled);
-    @include addBorder(toRem(2), map-get($colorMap, disabled));
-    .tk-button-icon--loading {
-      color: map-get($colorMap, textDisabled);
-    }
   }
   &.loading {
-    color: map-get($colorMap, text);
-    @include addBorder(toRem(2), map-get($colorMap, default));
-    .tk-button-icon--loading {
-      color: map-get($colorMap, text);
-    }
+    @include getButtonStyle($colorMap, text, default, default);
+    background-color: transparent;
   }
   @include focus-visible($colorMap, true);
 }

--- a/src/utils/mixins/_buttons.scss
+++ b/src/utils/mixins/_buttons.scss
@@ -17,7 +17,6 @@
   &:focus-visible {
     background-color: map-get($colorMap, focus);
     color: map-get($colorMap, focusText);
-    @include addFontIconColor(map-get($colorMap, focusText));
     outline: 0;
     @if $insetShadow {
       box-shadow: inset 0 0 0 toRem(2) map-get($colorMap, focusText),
@@ -33,22 +32,36 @@
 /* Applies color styles to filled buttons, buttons that do not have borders */
 @mixin styleFilledButton($colorMap) {
   background-color: map-get($colorMap, default);
-  @include addFontIconColor(map-get($colorMap, text));
+  color: map-get($colorMap, text);
   &:hover {
     background-color: map-get($colorMap, hover);
     color: map-get($colorMap, hoverText);
+    .tk-button-icon--loading {
+      color: map-get($colorMap, hoverText);
+    }
   }
   &:active {
     background-color: map-get($colorMap, active);
-    @include addFontIconColor(map-get($colorMap, activeText));
+    color: map-get($colorMap, activeText);
+    .tk-button-icon--loading {
+      color: map-get($colorMap, activeText);
+    }
   }
   &:disabled {
     background-color: map-get($colorMap, disabled);
-    @include addFontIconColor(map-get($colorMap, textDisabled));
+    color: map-get($colorMap, textDisabled);
+    .tk-button-icon--loading {
+      color: map-get($colorMap, textDisabled);
+    }
+  }
+  &:disabled.loading {
+    background-color: map-get($colorMap, default);
   }
   &.loading {
-    background-color: map-get($colorMap, default);
-    @include addFontIconColor(map-get($colorMap, text));
+    color: map-get($colorMap, text);
+    .tk-button-icon--loading {
+      color: map-get($colorMap, text);
+    }
   }
   @include focus-visible($colorMap);
 }
@@ -56,30 +69,38 @@
 /* Applies color styles to outline buttons, buttons that do not have a background */
 @mixin styleOutlinedButton($colorMap) {
   background-color: transparent;
+  color: map-get($colorMap, default);
   @include addBorder(toRem(2), map-get($colorMap, default));
-  @include addFontIconColor(map-get($colorMap, default));
   &:hover {
     background-color: map-get($colorMap, hover);
     color: map-get($colorMap, hoverText);
-    @include addFontIconColor(map-get($colorMap, hoverText));
     @include addBorder(toRem(2), map-get($colorMap, hoverText));
+    .tk-button-icon--loading {
+      color: map-get($colorMap, hoverText);
+    }
   }
   &:active {
     background-color: map-get($colorMap, active);
-    @include addBorder(toRem(2), map-get($colorMap, activeText));
     color: map-get($colorMap, activeText);
-    @include addFontIconColor(map-get($colorMap, activeText));
+    @include addBorder(toRem(2), map-get($colorMap, activeText));
+    .tk-button-icon--loading {
+      color: map-get($colorMap, activeText);
+    }
   }
   &:disabled {
     background-color: transparent;
-    @include addBorder(toRem(2), map-get($colorMap, disabled));
-    @include addFontIconColor(map-get($colorMap, textDisabled));
     color: map-get($colorMap, textDisabled);
+    @include addBorder(toRem(2), map-get($colorMap, disabled));
+    .tk-button-icon--loading {
+      color: map-get($colorMap, textDisabled);
+    }
   }
   &.loading {
-    background-color: transparent;
-    @include addBorder(toRem(2), map-get($colorMap, text));
-    @include addFontIconColor(map-get($colorMap, text));
+    color: map-get($colorMap, text);
+    @include addBorder(toRem(2), map-get($colorMap, default));
+    .tk-button-icon--loading {
+      color: map-get($colorMap, text);
+    }
   }
   @include focus-visible($colorMap, true);
 }


### PR DESCRIPTION
**Jira ticket**
https://perzoinc.atlassian.net/browse/APP-4649

**Changes**
This PR comes with another one (https://github.com/SymphonyPlatformSolutions/symphony-bdk-ui-toolkit-components/pull/323) to remove the '<span>' tag from the Button.
- Remove duplicated code
- Icon uses the inherited color
- Add 'tk-button-icon--loading' CSS class to set a color only on loading icon

**Demo**
**ℹ️  Expected: No regression in the colors of the Buttons**

**Before the changes**
<img width="629" alt="Screenshot 2021-10-28 at 15 48 12" src="https://user-images.githubusercontent.com/66668470/139269139-7521ec89-920d-4b99-8a53-b8c6a7fa045d.png">

---
**After**
<img width="649" alt="Screenshot 2021-10-28 at 15 48 03" src="https://user-images.githubusercontent.com/66668470/139269179-fa1ce549-db6d-4520-a992-1d4c370c8095.png">

