### PR TITLE
APP-4600 Apply color to hint description

### DIFF
--- a/src/components/atoms/_hint.scss
+++ b/src/components/atoms/_hint.scss
@@ -10,11 +10,13 @@ $backgroundColor: $scolor-graphite-plus-48;
   font-size: toRem(14);
   padding: toRem(16);
   text-align: left;
-  color: $scolor-graphite-minus-96;
   line-height: toRem(20);
   white-space: pre-line;
   min-width: toRem(200);
   max-width: toRem(500);
+  &__description {
+    color: $scolor-graphite-minus-96;
+  }
 
   &__arrow {
     $arrowSize: toRem(24);


### PR DESCRIPTION
### Description 
- Apply color to hint description


### Before
![Screenshot 2021-11-15 at 09 27 01](https://user-images.githubusercontent.com/68587873/141748109-1b4da8c2-b580-46c4-aa59-4c34f74e97c9.png)



### After
![Screenshot 2021-11-15 at 09 28 08](https://user-images.githubusercontent.com/68587873/141748138-855a67df-8f78-44c2-8bff-070b128a258c.png)

