### PR TITLE
APP-4692 fix: Added missing color to tertiary-destructive Button 

### DIFF
--- a/src/variables/themes/_dark.scss
+++ b/src/variables/themes/_dark.scss
@@ -46,7 +46,7 @@
   --tk-button-color-destructive-tertiary-active-text: #{getColor($red, '40')};
   --tk-button-color-destructive-tertiary-disabled: transparent;
   --tk-button-color-destructive-tertiary-text-disabled: #{getColor($red, '70')};
-  --tk-button-color-destructive-tertiary-text: #{getColor($red, '70')};
+  --tk-button-color-destructive-tertiary-text: #{getColor($red, '40')};
 
   // tertiary accent
   --tk-button-color-accent-tertiary-default: transparent;
@@ -54,7 +54,7 @@
   --tk-button-color-accent-tertiary-hover: #{getColor($electricity, '60')};
   --tk-button-color-accent-tertiary-active: #{getColor($electricity, '70')};
   --tk-button-color-accent-tertiary-hover-text: #{getColor($electricity, '30')};
-  --tk-button-color-accent-tertiary-active-text: #{getColor($electricity, '40')};
+  --tk-button-color-accent-tertiary-text-active: #{getColor($electricity, '40')};
   --tk-button-color-accent-tertiary-disabled: transparent;
   --tk-button-color-accent-tertiary-text-disabled: #{getColor(
       $electricity,
@@ -167,7 +167,7 @@
   --tk-timeline-border-color: #{getColor($graphite, '50')};
   --tk-timeline-expand-icon-color: #{getColor($graphite, '40')};
   --tk-timeline-hours-color: #{getColor($graphite, '05')};
-  
+
   // Divider
   --tk-divider-color: #{getColor($graphite, '70')};
 

--- a/src/variables/themes/_dark.scss
+++ b/src/variables/themes/_dark.scss
@@ -3,7 +3,7 @@
   // globals
   --tk-background: #{getColor($graphite, '80')};
   --tk-background-reverse: #{$scolor-white};
- 
+
   // Primary button
   --tk-button-color-primary-disabled: #{getColor($electricity, '70')};
   --tk-button-color-primary-text-disabled: #{getColor($electricity, '60')};
@@ -54,7 +54,7 @@
   --tk-button-color-accent-tertiary-hover: #{getColor($electricity, '60')};
   --tk-button-color-accent-tertiary-active: #{getColor($electricity, '70')};
   --tk-button-color-accent-tertiary-hover-text: #{getColor($electricity, '30')};
-  --tk-button-color-accent-tertiary-text-active: #{getColor($electricity, '40')};
+  --tk-button-color-accent-tertiary-active-text: #{getColor($electricity, '40')};
   --tk-button-color-accent-tertiary-disabled: transparent;
   --tk-button-color-accent-tertiary-text-disabled: #{getColor(
       $electricity,
@@ -170,5 +170,4 @@
 
   // Divider
   --tk-divider-color: #{getColor($graphite, '70')};
-
 }

--- a/src/variables/themes/accessors/colors/_index.scss
+++ b/src/variables/themes/accessors/colors/_index.scss
@@ -179,6 +179,8 @@ $--tk-button-color-destructive-secondary: (
 $--tk-button-color-destructive-tertiary: (
   default: var(--tk-button-color-destructive-tertiary-default, transparent),
   hover: var(--tk-button-color-destructive-tertiary-hover, getColor($red, '10')),
+  hoverText:
+  var(--tk-button-color-destructive-tertiary-hover-text, getColor($red, '50')),
   active:
     var(--tk-button-color-destructive-tertiary-active, getColor($red, '20')),
   disabled: var(--tk-button-color-destructive-tertiary-disabled, transparent),

--- a/src/variables/themes/accessors/colors/_index.scss
+++ b/src/variables/themes/accessors/colors/_index.scss
@@ -12,9 +12,12 @@ $--tk-main-text-color: var(--tk-main-text-color, $scolor-graphite);
 
 $--tk-outline-color: #88c0fb;
 
-$--tk-background:var(--tk-background, $scolor-white);
+$--tk-background: var(--tk-background, $scolor-white);
 
-$--tk-background-reverse:var( --tk-background-reverse,  getColor($graphite, '80'));
+$--tk-background-reverse: var(
+  --tk-background-reverse,
+  getColor($graphite, '80')
+);
 
 /** ======== Inputs and text areas ======== */
 
@@ -66,14 +69,37 @@ $--tk-input-disabled-background-color: var(
 );
 
 $--tk-input-checkbox-radio-color: (
-  iconDefault: var(--tk-input-checkbox-radio-color-icon-default, getColor($graphite, '50')), 
-  iconHover: var(--tk-input-checkbox-radio-color-icon-hover, getColor($electricity, '40')),
-  iconDisabled: var(--tk-input-checkbox-radio-color-icon-disabled, getColor($graphite, '20')), 
-  iconError: var(--tk-input-checkbox-radio-color-icon-error, getColor($red, '50')),
-  iconErrorHover: var(--tk-input-checkbox-radio-color-icon-error-hover, getColor($red, '40')),
-  iconChecked: var(--tk-input-checkbox-radio-color-icon-checked, getColor($electricity, '50')), 
-  textDefault: var(--tk-input-checkbox-radio-color-icon-text-default, getColor($graphite, '80')), 
-  textDisabled: var(--tk-input-checkbox-radio-color-icon-text-disabled, getColor($graphite, '30')),
+  iconDefault:
+    var(--tk-input-checkbox-radio-color-icon-default, getColor($graphite, '50')),
+  iconHover:
+    var(
+      --tk-input-checkbox-radio-color-icon-hover,
+      getColor($electricity, '40')
+    ),
+  iconDisabled:
+    var(
+      --tk-input-checkbox-radio-color-icon-disabled,
+      getColor($graphite, '20')
+    ),
+  iconError:
+    var(--tk-input-checkbox-radio-color-icon-error, getColor($red, '50')),
+  iconErrorHover:
+    var(--tk-input-checkbox-radio-color-icon-error-hover, getColor($red, '40')),
+  iconChecked:
+    var(
+      --tk-input-checkbox-radio-color-icon-checked,
+      getColor($electricity, '50')
+    ),
+  textDefault:
+    var(
+      --tk-input-checkbox-radio-color-icon-text-default,
+      getColor($graphite, '80')
+    ),
+  textDisabled:
+    var(
+      --tk-input-checkbox-radio-color-icon-text-disabled,
+      getColor($graphite, '30')
+    ),
 );
 
 $--tk-input-switch-default-line-color: var(
@@ -182,11 +208,14 @@ $--tk-button-color-destructive-tertiary: (
   default: var(--tk-button-color-destructive-tertiary-default, transparent),
   hover: var(--tk-button-color-destructive-tertiary-hover, getColor($red, '10')),
   hoverText:
-  var(--tk-button-color-destructive-tertiary-hover-text, getColor($red, '50')),
+    var(--tk-button-color-destructive-tertiary-hover-text, getColor($red, '50')),
   active:
-  var(--tk-button-color-destructive-tertiary-active, getColor($red, '20')),
+    var(--tk-button-color-destructive-tertiary-active, getColor($red, '20')),
   activeText:
-  var(--tk-button-color-destructive-tertiary-active-text, getColor($red, '60')),
+    var(
+      --tk-button-color-destructive-tertiary-active-text,
+      getColor($red, '60')
+    ),
   disabled: var(--tk-button-color-destructive-tertiary-disabled, transparent),
   text: var(--tk-button-color-destructive-tertiary-text, getColor($red, '50')),
   textDisabled:
@@ -207,7 +236,7 @@ $--tk-button-color-accent-tertiary: (
     var(--tk-button-color-accent-tertiary-active, getColor($electricity, '20')),
   activeText:
     var(
-      --tk-button-color-accent-tertiary-text-active,
+      --tk-button-color-accent-tertiary-active-text,
       getColor($electricity, '60')
     ),
   disabled: var(--tk-button-color-accent-tertiary-disabled, transparent),
@@ -418,7 +447,4 @@ $--tk-timeline-hours-color: var(
 );
 
 /** ======== divider ======== */
-$--tk-divider-color: var(
-  --tk-divider-color,
-  getColor($graphite, '20')
-);
+$--tk-divider-color: var(--tk-divider-color, getColor($graphite, '20'));

--- a/src/variables/themes/accessors/colors/_index.scss
+++ b/src/variables/themes/accessors/colors/_index.scss
@@ -134,6 +134,8 @@ $--tk-button-color-tertiary: (
   hoverText:
     var(--tk-button-color-tertiary-hover-text, getColor($graphite, '50')),
   active: var(--tk-button-color-tertiary-active, getColor($graphite, '20')),
+  activeText:
+    var(--tk-button-color-tertiary-active-text, getColor($graphite, '60')),
   disabled: var(--tk-button-color-tertiary-disabled, transparent),
   text: var(--tk-button-color-tertiary-text, getColor($graphite, '50')),
   textDisabled:
@@ -182,7 +184,9 @@ $--tk-button-color-destructive-tertiary: (
   hoverText:
   var(--tk-button-color-destructive-tertiary-hover-text, getColor($red, '50')),
   active:
-    var(--tk-button-color-destructive-tertiary-active, getColor($red, '20')),
+  var(--tk-button-color-destructive-tertiary-active, getColor($red, '20')),
+  activeText:
+  var(--tk-button-color-destructive-tertiary-active-text, getColor($red, '60')),
   disabled: var(--tk-button-color-destructive-tertiary-disabled, transparent),
   text: var(--tk-button-color-destructive-tertiary-text, getColor($red, '50')),
   textDisabled:
@@ -201,6 +205,11 @@ $--tk-button-color-accent-tertiary: (
     var(--tk-button-color-accent-tertiary-hover, getColor($electricity, '10')),
   active:
     var(--tk-button-color-accent-tertiary-active, getColor($electricity, '20')),
+  activeText:
+    var(
+      --tk-button-color-accent-tertiary-text-active,
+      getColor($electricity, '60')
+    ),
   disabled: var(--tk-button-color-accent-tertiary-disabled, transparent),
   text:
     var(--tk-button-color-accent-tertiary-text, getColor($electricity, '50')),
@@ -208,11 +217,6 @@ $--tk-button-color-accent-tertiary: (
     var(
       --tk-button-color-accent-tertiary-text-disabled,
       getColor($electricity, '20')
-    ),
-  activeText:
-    var(
-      --tk-button-color-accent-tertiary-text-active,
-      getColor($electricity, '60')
     ),
   focus:
     var(--tk-button-color-accent-tertiary-focus, getColor($electricity, '20')),


### PR DESCRIPTION
### Description 
-APP-4692 fix: Added missing text color to _tertiary-destructive_ Button when hover

### Bug:
<img width="287" alt="Screenshot 2021-12-03 at 08 02 15" src="https://user-images.githubusercontent.com/68587873/144559669-e401097e-e9e3-4962-a324-a46d4370c952.png">

### Fix:
<img width="261" alt="Screenshot 2021-12-03 at 08 01 24" src="https://user-images.githubusercontent.com/68587873/144559689-c80c76a8-8826-46e7-8022-915717ea1687.png">


